### PR TITLE
Combined dependency updates (2022-11-29)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3.0.1
+      - uses: actions/setup-dotnet@v3.0.3
         with:
             dotnet-version: '6.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3.0.1
+      - uses: actions/setup-dotnet@v3.0.3
         with:
             dotnet-version: '3.1.x'
-      - uses: actions/setup-dotnet@v3.0.1
+      - uses: actions/setup-dotnet@v3.0.3
         with:
             dotnet-version: '6.0.x'
 

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/setup-dotnet from 3.0.1 to 3.0.3](https://github.com/javiertuya/dotnet-test-split/pull/32)
- [Bump coverlet.collector from 3.1.2 to 3.2.0](https://github.com/javiertuya/dotnet-test-split/pull/31)