### PR TITLE
Combined dependency updates (2023-01-02)

### DIFF
--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     
     <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
 
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
 

--- a/TestAssetsNunit/TestAssetsNunit.csproj
+++ b/TestAssetsNunit/TestAssetsNunit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
     

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 
     <PackageReference Include="xunit" Version="2.4.2" />
     

--- a/TestDotnetTestSplit/TestDotnetTestSplit.csproj
+++ b/TestDotnetTestSplit/TestDotnetTestSplit.csproj
@@ -13,7 +13,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     
-    <PackageReference Include="VisualAssert" Version="2.2.1" />
+    <PackageReference Include="VisualAssert" Version="2.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TestDotnetTestSplit/TestDotnetTestSplit.csproj
+++ b/TestDotnetTestSplit/TestDotnetTestSplit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump MSTest.TestAdapter from 2.2.10 to 3.0.2](https://github.com/javiertuya/dotnet-test-split/pull/40)
- [Bump MSTest.TestFramework from 2.2.10 to 3.0.2](https://github.com/javiertuya/dotnet-test-split/pull/38)
- [Bump Microsoft.NET.Test.Sdk from 17.4.0 to 17.4.1](https://github.com/javiertuya/dotnet-test-split/pull/37)
- [Bump VisualAssert from 2.2.1 to 2.2.2](https://github.com/javiertuya/dotnet-test-split/pull/39)