### PR TITLE
Combined dependency updates (2023-06-03)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3.0.3
+      - uses: actions/setup-dotnet@v3.2.0
         with:
             dotnet-version: '6.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3.0.3
+      - uses: actions/setup-dotnet@v3.2.0
         with:
             dotnet-version: '3.1.x'
-      - uses: actions/setup-dotnet@v3.0.3
+      - uses: actions/setup-dotnet@v3.2.0
         with:
             dotnet-version: '6.0.x'
 

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -13,7 +13,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.3" />
     
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.3" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.3" />
     
     <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.3" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.3" />
 

--- a/TestAssetsNunit/TestAssetsNunit.csproj
+++ b/TestAssetsNunit/TestAssetsNunit.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="NUnit" Version="3.13.3" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/TestAssetsNunit/TestAssetsNunit.csproj
+++ b/TestAssetsNunit/TestAssetsNunit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
     

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 
     <PackageReference Include="xunit" Version="2.4.2" />
     

--- a/TestDotnetTestSplit/TestDotnetTestSplit.csproj
+++ b/TestDotnetTestSplit/TestDotnetTestSplit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 

--- a/TestDotnetTestSplit/TestDotnetTestSplit.csproj
+++ b/TestDotnetTestSplit/TestDotnetTestSplit.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     
     <PackageReference Include="VisualAssert" Version="2.2.2" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/setup-dotnet from 3.0.3 to 3.2.0](https://github.com/javiertuya/dotnet-test-split/pull/46)
- [Bump MSTest.TestAdapter from 3.0.2 to 3.0.3](https://github.com/javiertuya/dotnet-test-split/pull/47)
- [Bump MSTest.TestFramework from 3.0.2 to 3.0.3](https://github.com/javiertuya/dotnet-test-split/pull/49)
- [Bump Microsoft.NET.Test.Sdk from 17.5.0 to 17.6.0](https://github.com/javiertuya/dotnet-test-split/pull/48)
- [Bump NUnit3TestAdapter from 4.4.2 to 4.5.0](https://github.com/javiertuya/dotnet-test-split/pull/51)
- [Bump coverlet.collector from 3.2.0 to 6.0.0](https://github.com/javiertuya/dotnet-test-split/pull/50)