### PR TITLE
Combined dependency updates (2023-07-02)

### DIFF
--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
 

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.3" />
     

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
     
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/TestAssetsNunit/TestAssetsNunit.csproj
+++ b/TestAssetsNunit/TestAssetsNunit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
     

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 
     <PackageReference Include="xunit" Version="2.4.2" />
     

--- a/TestDotnetTestSplit/TestDotnetTestSplit.csproj
+++ b/TestDotnetTestSplit/TestDotnetTestSplit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 

--- a/TestDotnetTestSplit/TestDotnetTestSplit.csproj
+++ b/TestDotnetTestSplit/TestDotnetTestSplit.csproj
@@ -13,7 +13,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     
-    <PackageReference Include="VisualAssert" Version="2.2.2" />
+    <PackageReference Include="VisualAssert" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump MSTest.TestAdapter from 3.0.3 to 3.0.4](https://github.com/javiertuya/dotnet-test-split/pull/54)
- [Bump MSTest.TestFramework from 3.0.3 to 3.0.4](https://github.com/javiertuya/dotnet-test-split/pull/56)
- [Bump Microsoft.NET.Test.Sdk from 17.6.0 to 17.6.3](https://github.com/javiertuya/dotnet-test-split/pull/55)
- [Bump VisualAssert from 2.2.2 to 2.4.1](https://github.com/javiertuya/dotnet-test-split/pull/53)