### PR TITLE
Combined dependency updates (2023-08-02)

### DIFF
--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
     

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="xunit" Version="2.4.2" />
     
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Includes these updates:
- [Bump MSTest.TestAdapter from 3.0.4 to 3.1.1](https://github.com/javiertuya/dotnet-test-split/pull/61)
- [Bump MSTest.TestFramework from 3.0.4 to 3.1.1](https://github.com/javiertuya/dotnet-test-split/pull/59)
- [Bump xunit.runner.visualstudio from 2.4.5 to 2.5.0](https://github.com/javiertuya/dotnet-test-split/pull/60)