### PR TITLE
Combined dependency updates (2023-10-03)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-    assignees:
-      - "javiertuya" 
     open-pull-requests-limit: 20
 
   - package-ecosystem: github-actions
@@ -13,5 +11,3 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 20
-    assignees:
-      - "javiertuya" 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       packages: write 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v3.2.0
         with:
             dotnet-version: '6.0.x'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         framework: ['netcoreapp3.1', 'net6.0']
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v3.2.0
         with:
             dotnet-version: '3.1.x'

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="xunit" Version="2.5.0" />
     
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 
-    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
     
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Includes these updates:
- [Update dependabot.yml assignee](https://github.com/javiertuya/dotnet-test-split/pull/68)
- [Bump actions/checkout from 3 to 4](https://github.com/javiertuya/dotnet-test-split/pull/67)
- [Bump xunit.runner.visualstudio from 2.5.0 to 2.5.1](https://github.com/javiertuya/dotnet-test-split/pull/66)
- [Bump xunit from 2.5.0 to 2.5.1](https://github.com/javiertuya/dotnet-test-split/pull/65)