### PR TITLE
Combined dependency updates (2023-11-02)

### DIFF
--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
 
-    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.6.0" />
     
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="xunit" Version="2.5.1" />
     
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Includes these updates:
- [Bump xunit.runner.visualstudio from 2.5.1 to 2.5.3](https://github.com/javiertuya/dotnet-test-split/pull/71)
- [Bump xunit from 2.5.1 to 2.6.0](https://github.com/javiertuya/dotnet-test-split/pull/70)