### PR TITLE
Combined dependency updates (2023-12-02)

### DIFF
--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 

--- a/TestAssetsNunit/TestAssetsNunit.csproj
+++ b/TestAssetsNunit/TestAssetsNunit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
     

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
     <PackageReference Include="xunit" Version="2.6.0" />
     

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="xunit" Version="2.6.0" />
     
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
-    <PackageReference Include="xunit" Version="2.6.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
     
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>

--- a/TestDotnetTestSplit/TestDotnetTestSplit.csproj
+++ b/TestDotnetTestSplit/TestDotnetTestSplit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 


### PR DESCRIPTION
Includes these updates:
- [Bump Microsoft.NET.Test.Sdk from 17.7.2 to 17.8.0](https://github.com/javiertuya/dotnet-test-split/pull/74)
- [Bump xunit.runner.visualstudio from 2.5.3 to 2.5.4](https://github.com/javiertuya/dotnet-test-split/pull/75)
- [Bump xunit from 2.6.0 to 2.6.2](https://github.com/javiertuya/dotnet-test-split/pull/73)