### PR TITLE
Combined dependency updates (2024-02-04)

### DIFF
--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
 
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
     
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
-    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="xunit" Version="2.6.6" />
     
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Includes these updates:
- [Bump MSTest.TestAdapter from 3.1.1 to 3.2.0](https://github.com/javiertuya/dotnet-test-split/pull/83)
- [Bump MSTest.TestFramework from 3.1.1 to 3.2.0](https://github.com/javiertuya/dotnet-test-split/pull/85)
- [Bump xunit from 2.6.4 to 2.6.6](https://github.com/javiertuya/dotnet-test-split/pull/84)