### PR TITLE
Combined dependency updates (2024-11-02)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4.0.1
+      - uses: actions/setup-dotnet@v4.1.0
         with:
             dotnet-version: '8.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4.0.1
+      - uses: actions/setup-dotnet@v4.1.0
         with:
             dotnet-version: |
               6.0.x

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.2" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
     
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/TestDotnetTestSplit/TestDotnetTestSplit.csproj
+++ b/TestDotnetTestSplit/TestDotnetTestSplit.csproj
@@ -13,7 +13,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     
-    <PackageReference Include="VisualAssert" Version="2.5.0" />
+    <PackageReference Include="VisualAssert" Version="2.5.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump VisualAssert from 2.5.0 to 2.5.1](https://github.com/javiertuya/dotnet-test-split/pull/129)
- [Bump the mstest group with 2 updates](https://github.com/javiertuya/dotnet-test-split/pull/128)
- [Bump actions/setup-dotnet from 4.0.1 to 4.1.0](https://github.com/javiertuya/dotnet-test-split/pull/127)