### PR TITLE
Combined dependency updates (2025-04-02)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       packages: write 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4.3.0
+      - uses: actions/setup-dotnet@v4.3.1
         with:
             dotnet-version: '8.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       #prevents execution on PR or dependabot that fails with "Resource not accessible by integration" due to permissions
       - name: Publish test report
         if: ${{ always() && github.actor=='javiertuya' }} 
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v2
         with:
           name: test-report-${{ matrix.framework }}
           path: reports/dotnet-test-split-report.trx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4.3.0
+      - uses: actions/setup-dotnet@v4.3.1
         with:
             dotnet-version: |
               6.0.x

--- a/TestDotnetTestSplit/TestDotnetTestSplit.csproj
+++ b/TestDotnetTestSplit/TestDotnetTestSplit.csproj
@@ -13,7 +13,7 @@
 
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     
-    <PackageReference Include="VisualAssert" Version="2.5.1" />
+    <PackageReference Include="VisualAssert" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump VisualAssert from 2.5.1 to 2.6.0](https://github.com/javiertuya/dotnet-test-split/pull/148)
- [Bump actions/setup-dotnet from 4.3.0 to 4.3.1](https://github.com/javiertuya/dotnet-test-split/pull/147)
- [Bump dorny/test-reporter from 1 to 2](https://github.com/javiertuya/dotnet-test-split/pull/146)