### PR TITLE
Combined dependency updates (2026-03-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         run: ant report
       - name: Publish test report files
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-report-files-${{ matrix.framework }}
           path: |

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
     
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -13,7 +13,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
     
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
 

--- a/TestAssetsNunit/TestAssetsNunit.csproj
+++ b/TestAssetsNunit/TestAssetsNunit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 
     <PackageReference Include="NUnit" Version="4.3.2" />
     

--- a/TestAssetsNunit/TestAssetsNunit.csproj
+++ b/TestAssetsNunit/TestAssetsNunit.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.5.0" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 
     <PackageReference Include="xunit" Version="2.9.3" />
     

--- a/TestDotnetTestSplit/TestDotnetTestSplit.csproj
+++ b/TestDotnetTestSplit/TestDotnetTestSplit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 
     <PackageReference Include="NUnit" Version="4.4.0" />
 

--- a/expected/nunit-report.trx.split/TEST-TestAssetsNunit.One.ClassTwo.xml
+++ b/expected/nunit-report.trx.split/TEST-TestAssetsNunit.One.ClassTwo.xml
@@ -23,6 +23,9 @@ STACK TRACE:
    at TestAssetsNunit.One.ClassTwo.TestOneTwoFailException() in /home/runner/work/dotnet-test-split/dotnet-test-split/TestAssetsNunit/TestAssetsNunit.cs:line 51
    at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+1)    at TestAssetsNunit.One.ClassTwo.TestOneTwoFailException() in /TestAssetsNunit/TestAssetsNunit.cs:line 51
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
 </failure></testcase>
 <testcase classname="TestAssetsNunit.One.ClassTwo" name="TestOneTwoPass" outcome="Passed" time="0.0000649" />
 <testcase classname="TestAssetsNunit.One.ClassTwo" name="TestOneOneIgnored" outcome="NotExecuted" time="0.000247"><skipped /></testcase>

--- a/expected/nunit-report.trx.split/TEST-TestAssetsNunit.Stp.ClassStp.xml
+++ b/expected/nunit-report.trx.split/TEST-TestAssetsNunit.Stp.ClassStp.xml
@@ -1,18 +1,28 @@
 <testsuite name="TestAssetsNunit.Stp.ClassStp" tests="2" failures="2" errors="0" skipped="0" time="0.0021060000000000002" >
 <testcase classname="TestAssetsNunit.Stp.ClassStp" name="TestStpOne" outcome="Failed" time="0.001629"><failure>
 MESSAGE:
-System.Exception : This test setup fails
+SetUp : System.Exception : This test setup fails
 +++++++++++++++++++
 STACK TRACE:
+--SetUp
+   at TestAssetsNunit.Stp.ClassStp.SetupFail() in /TestAssetsNunit/TestAssetsNunit.cs:line 98
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+1) --SetUp
    at TestAssetsNunit.Stp.ClassStp.SetupFail() in /home/runner/work/dotnet-test-split/dotnet-test-split/TestAssetsNunit/TestAssetsNunit.cs:line 98
    at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
 </failure></testcase>
 <testcase classname="TestAssetsNunit.Stp.ClassStp" name="TestStpTwo" outcome="Failed" time="0.000477"><failure>
 MESSAGE:
-System.Exception : This test setup fails
+SetUp : System.Exception : This test setup fails
 +++++++++++++++++++
 STACK TRACE:
+--SetUp
+   at TestAssetsNunit.Stp.ClassStp.SetupFail() in /TestAssetsNunit/TestAssetsNunit.cs:line 98
+   at InvokeStub_ClassStp.SetupFail(Object, Object, IntPtr*)
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
+1) --SetUp
    at TestAssetsNunit.Stp.ClassStp.SetupFail() in /home/runner/work/dotnet-test-split/dotnet-test-split/TestAssetsNunit/TestAssetsNunit.cs:line 98
    at InvokeStub_ClassStp.SetupFail(Object, Object, IntPtr*)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit from 4.3.2 to 4.5.0](https://github.com/javiertuya/dotnet-test-split/pull/178)
- [Bump Microsoft.NET.Test.Sdk from 18.0.1 to 18.3.0](https://github.com/javiertuya/dotnet-test-split/pull/177)
- [Bump coverlet.collector from 6.0.4 to 8.0.0](https://github.com/javiertuya/dotnet-test-split/pull/176)
- [Bump the mstest group with 2 updates](https://github.com/javiertuya/dotnet-test-split/pull/175)
- [Bump actions/upload-artifact from 6 to 7](https://github.com/javiertuya/dotnet-test-split/pull/174)