### PR TITLE
Combined dependency updates (2026-04-05)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Select .NET Version
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@v5.2.0
         with:
             dotnet-version: '10.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Select .NET Version
-        uses: actions/setup-dotnet@v5.1.0
+        uses: actions/setup-dotnet@v5.2.0
         with:
             dotnet-version: |
               8.0.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       #prevents execution on PR or dependabot that fails with "Resource not accessible by integration" due to permissions
       - name: Publish test report
         if: ${{ always() && github.actor=='javiertuya' }} 
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         with:
           name: test-report-${{ matrix.framework }}
           path: reports/dotnet-test-split-report.trx

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -13,7 +13,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
     
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TestAssetsNunit/TestAssetsNunit.csproj
+++ b/TestAssetsNunit/TestAssetsNunit.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="NUnit" Version="4.5.0" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/TestAssetsNunit/TestAssetsNunit.csproj
+++ b/TestAssetsNunit/TestAssetsNunit.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 
-    <PackageReference Include="NUnit" Version="4.5.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit3TestAdapter from 6.1.0 to 6.2.0](https://github.com/javiertuya/dotnet-test-split/pull/184)
- [Bump NUnit from 4.5.0 to 4.5.1](https://github.com/javiertuya/dotnet-test-split/pull/183)
- [Bump coverlet.collector from 8.0.0 to 8.0.1](https://github.com/javiertuya/dotnet-test-split/pull/182)
- [Bump actions/setup-dotnet from 5.1.0 to 5.2.0](https://github.com/javiertuya/dotnet-test-split/pull/181)
- [Bump dorny/test-reporter from 2 to 3](https://github.com/javiertuya/dotnet-test-split/pull/180)