### PR TITLE
Combined dependency updates (2026-06-02)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Select .NET Version
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.3.0
         with:
             dotnet-version: '10.0.x'
       - name: Pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Select .NET Version
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.3.0
         with:
             dotnet-version: |
               8.0.x

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
 

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -13,7 +13,7 @@
 
     <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
     
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
 
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
     
     <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/TestAssetsNunit/TestAssetsNunit.csproj
+++ b/TestAssetsNunit/TestAssetsNunit.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 
-    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>

--- a/TestAssetsNunit/TestAssetsNunit.csproj
+++ b/TestAssetsNunit/TestAssetsNunit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 
     <PackageReference Include="NUnit" Version="4.5.1" />
     

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 
     <PackageReference Include="xunit" Version="2.9.3" />
     

--- a/TestDotnetTestSplit/TestDotnetTestSplit.csproj
+++ b/TestDotnetTestSplit/TestDotnetTestSplit.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 
     <PackageReference Include="NUnit" Version="4.4.0" />
 


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit from 4.5.1 to 4.6.1](https://github.com/javiertuya/dotnet-test-split/pull/194)
- [Bump Microsoft.NET.Test.Sdk from 18.5.1 to 18.6.0](https://github.com/javiertuya/dotnet-test-split/pull/193)
- [Bump coverlet.collector from 10.0.0 to 10.0.1](https://github.com/javiertuya/dotnet-test-split/pull/192)
- [Bump the mstest group with 2 updates](https://github.com/javiertuya/dotnet-test-split/pull/191)
- [Bump actions/setup-dotnet from 5.2.0 to 5.3.0](https://github.com/javiertuya/dotnet-test-split/pull/190)