### PR TITLE
Migrate TestAssets projects to net10.0

### DIFF
--- a/TestAssetsMstest/TestAssetsMstest.csproj
+++ b/TestAssetsMstest/TestAssetsMstest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TestAssetsNunit/TestAssetsNunit.csproj
+++ b/TestAssetsNunit/TestAssetsNunit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TestAssetsXunit/TestAssetsXunit.csproj
+++ b/TestAssetsXunit/TestAssetsXunit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/expected/mstest-report.trx.split/TEST-TestAssetsMstest.One.ClassTwo.xml
+++ b/expected/mstest-report.trx.split/TEST-TestAssetsMstest.One.ClassTwo.xml
@@ -8,7 +8,7 @@ STACK TRACE:
    at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEqual[T](T expected, T actual, IEqualityComparer`1 comparer, String message, String expectedExpression, String actualExpression) in /_/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs:line 492
    at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEqual[T](T expected, T actual, String message, String expectedExpression, String actualExpression) in /_/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs:line 405
    at TestAssetsMstest.One.ClassTwo.TestOneTwoFailMessage() in /home/runner/work/dotnet-test-split/dotnet-test-split/TestAssetsMstest/TestAssetsMstest.cs:line 46
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)</failure></testcase>
 <testcase classname="TestAssetsMstest.One.ClassTwo" name="TestOneOneIgnoredWithCause" outcome="NotExecuted" time="0.0000494000000017536"><skipped /></testcase>
 <testcase classname="TestAssetsMstest.One.ClassTwo" name="TestOneTwoPass" outcome="Passed" time="0.0001115" />
@@ -20,7 +20,7 @@ System.Exception: This is an exception message
 +++++++++++++++++++
 STACK TRACE:
    at TestAssetsMstest.One.ClassTwo.TestOneTwoFailException() in /home/runner/work/dotnet-test-split/dotnet-test-split/TestAssetsMstest/TestAssetsMstest.cs:line 51
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
 </failure></testcase>
 <testcase classname="TestAssetsMstest.One.ClassTwo" name="TestOneTwoFail" outcome="Failed" time="0.0006018"><failure>
@@ -32,6 +32,6 @@ STACK TRACE:
    at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEqual[T](T expected, T actual, IEqualityComparer`1 comparer, String message, String expectedExpression, String actualExpression) in /_/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs:line 492
    at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEqual[T](T expected, T actual, String message, String expectedExpression, String actualExpression) in /_/src/TestFramework/TestFramework/Assertions/Assert.AreEqual.cs:line 405
    at TestAssetsMstest.One.ClassTwo.TestOneTwoFail() in /home/runner/work/dotnet-test-split/dotnet-test-split/TestAssetsMstest/TestAssetsMstest.cs:line 41
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)</failure></testcase>
 </testsuite>

--- a/expected/mstest-report.trx.split/TEST-TestAssetsMstest.Stp.ClassStp.xml
+++ b/expected/mstest-report.trx.split/TEST-TestAssetsMstest.Stp.ClassStp.xml
@@ -5,7 +5,7 @@ Initialization method TestAssetsMstest.Stp.ClassStp.SetupFail threw exception. S
 +++++++++++++++++++
 STACK TRACE:
    at TestAssetsMstest.Stp.ClassStp.SetupFail() in /home/runner/work/dotnet-test-split/dotnet-test-split/TestAssetsMstest/TestAssetsMstest.cs:line 98
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
 </failure></testcase>
 <testcase classname="TestAssetsMstest.Stp.ClassStp" name="TestStpTwo" outcome="Failed" time="0.000578"><failure>

--- a/expected/nunit-report.trx.split/TEST-TestAssetsNunit.One.ClassTwo.xml
+++ b/expected/nunit-report.trx.split/TEST-TestAssetsNunit.One.ClassTwo.xml
@@ -21,10 +21,10 @@ System.Exception : This is an exception message
 +++++++++++++++++++
 STACK TRACE:
    at TestAssetsNunit.One.ClassTwo.TestOneTwoFailException() in /home/runner/work/dotnet-test-split/dotnet-test-split/TestAssetsNunit/TestAssetsNunit.cs:line 51
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
 1)    at TestAssetsNunit.One.ClassTwo.TestOneTwoFailException() in /TestAssetsNunit/TestAssetsNunit.cs:line 51
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
 </failure></testcase>
 <testcase classname="TestAssetsNunit.One.ClassTwo" name="TestOneTwoPass" outcome="Passed" time="0.0000649" />

--- a/expected/nunit-report.trx.split/TEST-TestAssetsNunit.Stp.ClassStp.xml
+++ b/expected/nunit-report.trx.split/TEST-TestAssetsNunit.Stp.ClassStp.xml
@@ -6,11 +6,11 @@ SetUp : System.Exception : This test setup fails
 STACK TRACE:
 --SetUp
    at TestAssetsNunit.Stp.ClassStp.SetupFail() in /TestAssetsNunit/TestAssetsNunit.cs:line 98
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
 1) --SetUp
    at TestAssetsNunit.Stp.ClassStp.SetupFail() in /home/runner/work/dotnet-test-split/dotnet-test-split/TestAssetsNunit/TestAssetsNunit.cs:line 98
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
 </failure></testcase>
 <testcase classname="TestAssetsNunit.Stp.ClassStp" name="TestStpTwo" outcome="Failed" time="0.000477"><failure>

--- a/expected/xunit-report.trx.split/TEST-TestAssetsXunit.One.ClassTwo.xml
+++ b/expected/xunit-report.trx.split/TEST-TestAssetsXunit.One.ClassTwo.xml
@@ -7,7 +7,7 @@ Actual:   2
 +++++++++++++++++++
 STACK TRACE:
    at TestAssetsXunit.One.ClassTwo.TestOneTwoFail() in /home/runner/work/dotnet-test-split/dotnet-test-split/TestAssetsXunit/TestAssetsXunit.cs:line 41
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)</failure></testcase>
 <testcase classname="TestAssetsXunit.One.ClassTwo" name="TestAssetsXunit.One.ClassTwo.TestOneOneIgnoredWithCause" outcome="NotExecuted" time="0.001"><skipped /></testcase>
 <testcase classname="TestAssetsXunit.One.ClassTwo" name="TestAssetsXunit.One.ClassTwo.TestOneOneIgnored" outcome="NotExecuted" time="0.001"><skipped /></testcase>
@@ -18,7 +18,7 @@ System.Exception : This is an exception message
 +++++++++++++++++++
 STACK TRACE:
    at TestAssetsXunit.One.ClassTwo.TestOneTwoFailException() in /home/runner/work/dotnet-test-split/dotnet-test-split/TestAssetsXunit/TestAssetsXunit.cs:line 51
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)</failure></testcase>
 <testcase classname="TestAssetsXunit.One.ClassTwo" name="TestAssetsXunit.One.ClassTwo.TestOneTwoFailMessage" outcome="Failed" time="0.0009274"><failure>
 MESSAGE:
@@ -26,6 +26,6 @@ This is a failure message
 +++++++++++++++++++
 STACK TRACE:
    at TestAssetsXunit.One.ClassTwo.TestOneTwoFailMessage() in /home/runner/work/dotnet-test-split/dotnet-test-split/TestAssetsXunit/TestAssetsXunit.cs:line 46
-   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)</failure></testcase>
 </testsuite>


### PR DESCRIPTION
﻿## .NET 8 ? .NET 10 migration (TestAssets)

Updates the target framework of the test asset projects from `net8` to `net10.0`:

- `TestAssetsMstest/TestAssetsMstest.csproj`
- `TestAssetsNunit/TestAssetsNunit.csproj`
- `TestAssetsXunit/TestAssetsXunit.csproj`

The main `DotnetTestSplit` tool and its test project remain **multi-target** (`net8.0;net10.0`) and are **left unchanged**.

?? Generated with [Claude Code](https://claude.com/claude-code)
