### PR TITLE
Fix environment-dependent path and locale in split comparison tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Force English UI culture so localized framework messages (e.g. MSTest asserts)
+    # in the generated trx match the expected files, independently of the runner language
+    env:
+      DOTNET_CLI_UI_LANGUAGE: en
     strategy:
       matrix:
         framework: ['net8.0', 'net10.0']

--- a/TestDotnetTestSplit/TestAll.cs
+++ b/TestDotnetTestSplit/TestAll.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Text.RegularExpressions;
 using System.Linq;
 using System.Xml.Linq;
-using System;
 using Giis.Visualassert;
 using Giis.DotnetTestSplit;
 
@@ -69,12 +68,10 @@ namespace Test4Giis.DotnetTestSplit
             string xml = xDoc.ToString();
             string regex = "time=\"([0-9E\\-\\.])*\"";
             xml = Regex.Replace(xml, regex, "time=\"\"");
-            //normalize absolute file paths (expected files are stored without the path of the solution)
+            //normalize absolute source paths in stack traces so the comparison is independent
+            //of the environment (CI vs local): strip everything before the TestAssets* project folder
             xml = xml.Replace(@"\", "/");
-            string[] curDir = Directory.GetCurrentDirectory().Replace(@"\", "/").Split("/");
-            string baseDir = string.Join("/", curDir, 0, curDir.Length - 4);
-            xml = xml.Replace(baseDir, "", StringComparison.InvariantCultureIgnoreCase);
-            //xml = xml.Replace("/home/runner/work/dotnet-test-split/dotnet-test-split/", "");
+            xml = Regex.Replace(xml, @"in [^\n]*?/(TestAssets(Mstest|Nunit|Xunit))/", "in /$1/");
 
             return xml.Replace("\r", "").Replace("\n\n", "\n");
         }

--- a/run-test.bat
+++ b/run-test.bat
@@ -1,5 +1,9 @@
+REM Force English UI culture so localized framework messages (e.g. MSTest asserts)
+REM in the generated trx match the expected files, independently of the OS language
+set DOTNET_CLI_UI_LANGUAGE=en
+
 REM Prepare test assets
-dotnet test TestAssetsMstest/TestAssetsMstest.csproj --logger "trx;LogFileName=../../reports/mstest-report.trx" 
+dotnet test TestAssetsMstest/TestAssetsMstest.csproj --logger "trx;LogFileName=../../reports/mstest-report.trx"
 dotnet test TestAssetsNunit/TestAssetsNunit.csproj --logger "trx;LogFileName=../../reports/nunit-report.trx" 
 dotnet test TestAssetsXunit/TestAssetsXunit.csproj --logger "trx;LogFileName=../../reports/xunit-report.trx" 
 


### PR DESCRIPTION
## Problem
The split comparison tests (`TestDotnetTestSplit`) were only reproducible in the exact GitHub Actions environment:

1. **Path inconsistency**: `ReadComparable` stripped a base directory computed dynamically from `Directory.GetCurrentDirectory()` (`curDir.Length - 4`), while the `expected/` fixtures had the CI absolute path (`/home/runner/work/dotnet-test-split/dotnet-test-split/`) baked into their stack traces. These only matched inside that CI path, so the tests failed on any local checkout.
2. **Locale inconsistency** (found while running locally on a Spanish Windows): MSTest emits localized assertion/initialization messages using the OS UI culture, so the generated trx did not match the English `expected/` fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)