### PR TITLE
Make split comparison tests create the reports folder if missing

### DIFF
--- a/TestDotnetTestSplit/TestAll.cs
+++ b/TestDotnetTestSplit/TestAll.cs
@@ -46,6 +46,9 @@ namespace Test4Giis.DotnetTestSplit
             string testFileName = "TEST-TestAssets" + framework + "." + testClass + ".xml";
             string expectedFolder = "../../../../expected/" + framework.ToLower() + "-report.trx.split";
             string outFolder = "../../../../reports/" + framework.ToLower() + "-report.trx.split";
+            //create the reports output folder if it does not exist so a standalone run does not
+            //crash with DirectoryNotFoundException; a missing actual file just fails the comparison
+            Directory.CreateDirectory(outFolder);
             //remove times and sort expected and actual to make comparable
             string expected = ReadComparable(Path.Combine(expectedFolder, testFileName));
             string actual = ReadComparable(Path.Combine(outFolder, testFileName));
@@ -55,6 +58,10 @@ namespace Test4Giis.DotnetTestSplit
         }
         private string ReadComparable(string fileName)
         {
+            //when the actual splitted file has not been generated, return empty content so the
+            //comparison fails clearly (showing the missing file) instead of throwing
+            if (!File.Exists(fileName))
+                return "";
             //sort by inner elements (testcase)
             var xDoc = XDocument.Load(fileName);
             var newxDoc = new XElement("testsuite", xDoc.Root


### PR DESCRIPTION
## Problem
Running the split comparison tests (`TestDotnetTestSplit`) on a clean checkout where the `reports/` folder does not exist crashed with `DirectoryNotFoundException` while loading the actual splitted file, instead of a readable test failure.

## Fix
- Create the `reports/<framework>-report.trx.split` output folder before comparing, so a standalone run does not crash with `DirectoryNotFoundException`.
- In `ReadComparable`, treat a missing actual file as empty content, so the comparison fails clearly ("Actual is empty", showing the missing file) instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)