### PR TITLE
ci: avoid duplicate workflow run on pull requests from the local repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    #avoids duplicate execution of pr from local repo, but allows pr from forked repos and dependabot
+    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'dependabot/')))
     # Force English UI culture so localized framework messages (e.g. MSTest asserts)
     # in the generated trx match the expected files, independently of the runner language
     env:


### PR DESCRIPTION
Adds the conditional that prevents the test workflow from running twice on pull requests created from a branch of this repo.

- PR from a local branch: only the `push` event runs, the `pull_request` one is skipped.
- PR from a fork or from dependabot: the `pull_request` event runs.

Only the test jobs are affected.
